### PR TITLE
Avoid transitive use of the verb 'ritornare'

### DIFF
--- a/intro-3/src/arrays/arrays.js
+++ b/intro-3/src/arrays/arrays.js
@@ -120,6 +120,6 @@ export function every(array, predicate) {}
 // Implementare il metodo nativo Array.reduce()
 export function reduce(array, reducer, initialState) {}
 
-// Dato un array e una funzione, spostare alla fine dell'array l'elemento per il quale la funzione ritorna true
+// Dato un array e una funzione, spostare alla fine dell'array l'elemento per il quale la funzione restituisce true
 // Nota: soltanto uno degli elementi soddisfa la funzione shouldMove
 export function moveToEnd(array, shouldMove) {}

--- a/intro-3/src/arrays/arrays.js
+++ b/intro-3/src/arrays/arrays.js
@@ -19,8 +19,8 @@ export function insertIntoArray(array, newElement, index) {}
 // Restituire null se non viene trovato nulla
 export function findBy(array, condition) {}
 
-// Come `findBy`, ma ritorna tutti gli elementi per i quali `condition` risulta vera
-// Se per nessun elemento risulta vera, ritornare un array vuoto
+// Come `findBy`, ma restituisce tutti gli elementi per i quali `condition` risulta vera
+// Se per nessun elemento risulta vera, restituire un array vuoto
 export function filterBy(array, condition) {}
 
 // Dato un array e un elemento, se l'elemento non è presente nell'array va inserito alla fine
@@ -28,7 +28,7 @@ export function filterBy(array, condition) {}
 export function toggleArrayItem(array, element) {}
 
 // Rimuove dall'array l'elemento all'indice specificato
-// Se l'indice è superiore o inferiore alla lunghezza dell'array, ritornare l'array originale
+// Se l'indice è superiore o inferiore alla lunghezza dell'array, restituire l'array originale
 export function removeFromArray(array, index) {}
 
 // Dati 2 o più array, unirli in un unico array
@@ -65,7 +65,7 @@ export function addExtraProperties(array, properties) {}
 export function removeProperties(array, properties) {}
 
 // Dato un array di oggetti con una chiave id e un array di id selezionati,
-// ritornare un nuovo array in cui gli elementi selezionati hanno la proprietà `selected`= true
+// restituire un nuovo array in cui gli elementi selezionati hanno la proprietà `selected`= true
 // Es.: [{ id: 1, name: 'A' }, { id: 2, name: 'B' }, { id: 3, name: 'C' }] e selectedIds = [2, 3]
 // deve restituire [{ id: 1, name: 'A' }, { id: 2, name: 'B', selected: true }, { id: 3, name: 'C', selected: true }]
 // L'array originale e i suoi elementi non devono essere modificati
@@ -74,16 +74,16 @@ export function setSelected(array, selectedIds) {}
 // Dato un array di oggetti, rimapparlo estraendo la chiave specificata
 // Es.: [{ id: 1, name: 'A' }, { id: 2, name: 'B' }, { id: 3, name: 'B' }] con chiave 'name'
 // deve restituire ['A', 'B', 'C']
-// Se la chiave non esiste, ritornare l'elemento originale
+// Se la chiave non esiste, restituire l'elemento originale
 export function mapTo(array, key) {}
 
 // Dato un array di oggetti e una funzione `predicate`, eseguire la funzione per ogni elemento
-// e ritornare true se per TUTTI è valida, altrimenti ritornare false
+// e restituire true se per TUTTI è valida, altrimenti restituire false
 // Es.: [{ id: 1, age: 32 }, { id: 2, age: 29 }] con predicate = (item) => item.age > 30,
-// `areItemsValid` ritorna false perché non tutti gli elementi hanno `age` maggiore di 30
+// `areItemsValid` restituisce false perché non tutti gli elementi hanno `age` maggiore di 30
 export function areItemsValid(array, predicate) {}
 
-// Dato un array di stringhe, un array di oggetti e una chiave, ritornare un nuovo array
+// Dato un array di stringhe, un array di oggetti e una chiave, restituire un nuovo array
 // dove ogni elemento del primo è sostuito col corrispondente elemento del secondo in base al valore di `key`
 // Es. array = ['11', '22', '33'], dataArray = [{ id: '33', name: 'A' }, { id: '11', name: 'B' }, { id: '22', name: 'C' }], key = 'id'
 // `populate` reve restituire [{ id: '11', name: 'B' }, { id: '22', name: 'C' }, { id: '33', name: 'A' }]

--- a/intro-3/src/immutability/immutability.js
+++ b/intro-3/src/immutability/immutability.js
@@ -25,17 +25,17 @@ const user10 = Object.freeze({
 export const users = Object.freeze([user10])
 
 // addressChanges è un oggetto che contiene una o più proprietà di Address da cambiare, ad esempio { city: London }
-// Ritornare l'array di utenti con le proprietà cambiate, mantenendo invariate quelle non presenti in addressChanges
+// Restituire l'array di utenti con le proprietà cambiate, mantenendo invariate quelle non presenti in addressChanges
 export const changeUsersAddress = (users, addressChanges) => {}
 
-// Ritornare l'array di utenti senza geo in address
+// Restituire l'array di utenti senza geo in address
 export const removeAddressCoordinates = (users) => {}
 
-// Ritornare l'array di utenti senza company
+// Restituire l'array di utenti senza company
 export const removeCompanyInfo = (users) => {}
 
-// Aggiungere newUser a users e ritornare l'array
+// Restituire newUser a users e restituire l'array
 export const addNewUser = (users, newUser) => {}
 
-// Ritornare l'array di utenti con lat e lng dentro geo convertiti in numero, non stringa
+// Restituire l'array di utenti con lat e lng dentro geo convertiti in numero, non stringa
 export const convertUsersGeoToNumber = (users) => {}

--- a/intro-3/src/objects/objects.js
+++ b/intro-3/src/objects/objects.js
@@ -37,14 +37,14 @@ export function arrayToObjectDeep(array) {}
 // Dato un oggetto e una funzione `predicate` da chiamare con la coppia chiave-valore,
 // restituire true se almeno una delle proprietà dell'oggetto soddisfa la funzione `predicate`.
 // Es.: { name: 'Mary', age: 99, children: 4 } con predicate = (key, value) => value > 10
-// ritorna true perché è presente una proprietà maggiore di 10 (age)
+// restituisce true perché è presente una proprietà maggiore di 10 (age)
 export function hasValidProperty(object, predicate) {}
 
 // Dato un oggetto, estrarre tutti i valori che sono a loro volta oggetti in un oggetto separato, usando come chiave il loro id;
 // rimuovere la chiave nell'oggetto di partenza e sostituirla con `{nome_chiave}Id` e usare come valore l'id dell'oggetto estratto.
 // Es.: { id: 1, name: 'John', car: { id: 33, manufacturer: 'Ford' } } restituisce due oggetti:
 // { id: 1, name: 'John', carId: 33 } e l'altro { 33: { id: 33, manufacturer: 'Ford' } }
-// Ritornare un array con i due oggetti (vedere il test per altri esempi)
+// Restituire un array con i due oggetti (vedere il test per altri esempi)
 // Idealmente dovrebbe funzionare per ogni oggetto trovato dentro l'oggetto di partenza, anche quelli annidati
 export function normalizeObject(object) {}
 
@@ -64,9 +64,9 @@ export function countTreeLeafNodes(tree) {}
 
 // Dati un oggetto e un path di tipo stringa, `get` deve restituire la proprietà al path specificato.
 // Se path contiene punti, si tratta di proprietà annidate. `get` deve funzionare anche con gli array,
-// specificando un numero come indice. Se la proprietà non esiste ritornare fallback o undefined.
-// Es. 1: { address: { city: 'New York' } } e 'address.city' ritorna 'New York'
-// Es. 2: { movies: ['Shrek', 'Shrek 2'] } e 'movies.1' ritorna 'Shrek 2'
+// specificando un numero come indice. Se la proprietà non esiste restituire fallback o undefined.
+// Es. 1: { address: { city: 'New York' } } e 'address.city' restituisce 'New York'
+// Es. 2: { movies: ['Shrek', 'Shrek 2'] } e 'movies.1' restituisce 'Shrek 2'
 export function get(object, path, fallback) {}
 
 // Dato un oggetto con una struttura non uniforme contentente informazioni geografiche
@@ -78,7 +78,7 @@ export function createGeoJSON(data) {}
 // Dati un array contentente le coordinate [lng, lat] di alcune geometrie (linee e punti),
 // e un punto con coordinate [lng, lat], stabilire se il punto interseca una o più geometrie del primo array.
 // Se sì, convertire l'array in un oggetto GeoJSON valido, dove la/le feature intersecate
-// hanno `highlighted: true` all'interno dell'oggetto `properties`. Se il punto non interseca nulla, ritornare null.
+// hanno `highlighted: true` all'interno dell'oggetto `properties`. Se il punto non interseca nulla, restituire null.
 // Per vedere i dati in input e il risultato finale, fare riferimento ai test.
 // NOTA: usare booleanIntersects (https://turfjs.org/docs/#booleanIntersects) per controllare se una geometria ne interseca un'altra.
 export function highlightActiveFeatures(geoJSON, point) {}


### PR DESCRIPTION
Avoid transitive use of the verb _ritornare_, which is more akin to conversational language and should only be used in its intransitive form and meaning in the general case. Use _restituire_ instead, which directly translates _to return_ in the semantic context of interest.
See, e.g., [Treccani Grammar Q&A](https://www.treccani.it/magazine/lingua_italiana/domande_e_risposte/grammatica/grammatica_499.html) for a discussion of this common and recurring issue.